### PR TITLE
Add renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,6 @@
+{
+    $schema: "https://docs.renovatebot.com/renovate-schema.json",
+    extends: [
+        "config:recommended",
+    ],
+}


### PR DESCRIPTION
## Related issues
- #5 

## Description
Add `renovate.json5` to enable Renovate bot.

The GitHub Actions workflow files in this repository use old action versions, and so do the repositories created based on this template repository.

## Test results
None.

## Impact
New repositories created based on this repository will contain the Renovate config file.