### PR TITLE
feat: Iteration自動付与のCaller workflowを追加

### DIFF
--- a/.github/workflows/close-set-iteration.yml
+++ b/.github/workflows/close-set-iteration.yml
@@ -1,0 +1,14 @@
+name: Set Iteration on Close
+
+on:
+  issues:
+    types: [closed]
+  pull_request:
+    types: [closed]
+
+jobs:
+  set-iteration:
+    uses: ut-issl/se-team-hub/.github/workflows/set-iteration-on-close.yml@main
+    secrets:
+      ITERATION_AUTOMATION_APP_ID: ${{ secrets.ITERATION_AUTOMATION_APP_ID }}
+      ITERATION_AUTOMATION_APP_PRIVATE_KEY: ${{ secrets.ITERATION_AUTOMATION_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- Issue/PRがCloseされたときに、se-team-hubのReusable workflowを呼び出してGitHub ProjectのIterationを自動設定するCaller workflowを追加

## 前提
- ut-issl/se-team-hub#93 がmainにマージされていること
- Organization Secretsに `ITERATION_AUTOMATION_APP_ID`, `ITERATION_AUTOMATION_APP_PRIVATE_KEY` が登録済みであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)