### PR TITLE
feat: 系ラベル自動付与のCaller workflowを追加

### DIFF
--- a/.github/workflows/auto-label-subsystem.yml
+++ b/.github/workflows/auto-label-subsystem.yml
@@ -1,0 +1,11 @@
+name: Auto Label Subsystem
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  auto-label:
+    uses: ut-issl/se-team-hub/.github/workflows/auto-label-subsystem.yml@main


### PR DESCRIPTION
## Summary
- リポジトリのTopicに基づいてIssue/PRに系ラベルを自動付与するCaller workflowを追加
- se-team-hubのReusable workflow（ut-issl/se-team-hub#94）を呼び出す

## 前提
- ut-issl/se-team-hub#94 がmainにマージされていること
- リポジトリに適切なTopicが設定されていること（例: `geox-cdh`）
- リポジトリに系ラベル（`sys:CDH` など）が定義されていること（#12）

🤖 Generated with [Claude Code](https://claude.com/claude-code)