### PR TITLE
feat: PR作成者の自動Assignee付与を追加

### DIFF
--- a/.github/workflows/auto-assign-pr-creator.yml
+++ b/.github/workflows/auto-assign-pr-creator.yml
@@ -1,0 +1,9 @@
+name: Auto Assign PR Creator
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  assign:
+    uses: ut-issl/se-team-hub/.github/workflows/auto-assign-pr-creator.yml@main


### PR DESCRIPTION
## Summary
- PR作成者を自動でAssigneeに設定するCaller Workflowを追加
- se-team-hubのReusable Workflow（`auto-assign-pr-creator.yml`）を呼び出す

## 依存関係
- ut-issl/se-team-hub の Reusable Workflow が先にマージされている必要あり

## Test plan
- [ ] se-team-hub側のPRがマージされた後、このリポジトリでPRを作成してAssigneeが自動設定されることを確認