### PR TITLE
feat: TAGラベル定義を追加

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -107,9 +107,6 @@
   description: "ソフトウェア"
   color: "D4C5F9"
 
-- name: ":satellite: WINGS"
-  description: "Web-based INterface Ground-station Software"
-  color: "F0F0F0"
 
 # TAGラベル（不要なものはリポジトリごとに削除してください）
 - name: "tag::formal-methods"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -106,3 +106,20 @@
 - name: "sys::SW"
   description: "ソフトウェア"
   color: "D4C5F9"
+
+- name: ":satellite: WINGS"
+  description: "Web-based INterface Ground-station Software"
+  color: "F0F0F0"
+
+# TAGラベル（不要なものはリポジトリごとに削除してください）
+- name: "tag::formal-methods"
+  description: "Formal Methods TAG"
+  color: "FF7A00"
+
+- name: "tag::autonomy"
+  description: "Autonomy TAG"
+  color: "00B8FF"
+
+- name: "tag::inference"
+  description: "Inference TAG"
+  color: "7A5CFF"


### PR DESCRIPTION
## Summary
- rg-seai-hubのラベル定義に合わせて、TAGラベルをrepository-templateに追加
  - `tag::formal-methods`
  - `tag::autonomy`
  - `tag::inference`
- 不要なラベルはリポジトリごとに削除可能

## Test plan
- [ ] labeler workflowがdry-runで正常に動作することを確認