### PR TITLE
chore: introduce linter and formatter configurations

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,0 +1,2 @@
+[tool.commitizen]
+name = "cz_conventional_commits"

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/.markdownlint-cli2.yaml
+++ b/.github/.markdownlint-cli2.yaml
@@ -1,0 +1,4 @@
+---
+config:
+  # Issue and pull request templates do not start with an H1 by convention.
+  MD041: false

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,6 @@
+---
+gitignore: true
+
+config:
+  MD013:
+    line_length: 120

--- a/.tombi.toml
+++ b/.tombi.toml
@@ -1,0 +1,3 @@
+[format]
+[format.rules]
+line-width = 120

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,4 @@
+[default.extend-words]
+
+[files]
+extend-exclude = []

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,24 @@
+---
+extends: default
+
+rules:
+  document-start:
+    present: true
+    ignore: |
+      .github/workflows/*.yml
+      .github/workflows/*.yaml
+  truthy:
+    ignore: |
+      .github/workflows/*.yml
+      .github/workflows/*.yaml
+  comments:
+    ignore: |
+      .github/workflows/*.yml
+      .github/workflows/*.yaml
+  comments-indentation:
+    ignore: |
+      .github/workflows/*.yml
+      .github/workflows/*.yaml
+      .pre-commit-config.yaml
+  line-length:
+    max: 120


### PR DESCRIPTION
linter / formatter の設定ファイルを導入する。

- markdownlint-cli2（リポジトリ全体と `.github` 用）
- tombi（TOML）
- typos（スペルチェック）
- yamllint（YAML）
- Commitizen（Conventional Commits）
- `.gitattributes`

設定を置くだけで、これらを実行する仕組みは pre-commit が #19、CI（`ci.yaml`）が #22 で追加する。そのため、この PR 単体ではまだ lint は実行されない。
