### PR TITLE
chore: introduce pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,61 @@
+---
+default_stages: [pre-commit]
+
+repos:
+  - repo: https://github.com/crate-ci/typos
+    rev: aca895bf05aec0cb7dffa6f94495e923224d9f17  # frozen: v1.46.2
+    hooks:
+      - id: typos
+        args: ["--force-exclude"]
+
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: 996abf60411a8d954288ac9856aae7602b80cbda  # frozen: v0.22.1
+    hooks:
+      - id: markdownlint-cli2
+
+  - repo: https://github.com/tombi-toml/tombi-pre-commit
+    rev: 92b75e984d8f88579b21001de632b48149d8166a  # frozen: v0.11.6
+    hooks:
+      - id: tombi-format
+      - id: tombi-lint
+
+  - repo: https://github.com/adrienverge/yamllint
+    rev: cba56bcde1fdd01c1deb3f945e69764c291a6530  # frozen: v1.38.0
+    hooks:
+      - id: yamllint
+        args: ["--strict", "-c=.yamllint.yaml"]
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
+    hooks:
+      - id: fix-byte-order-marker
+      - id: mixed-line-ending
+        args: ["--fix=lf"]
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+        args: ["--markdown-linebreak-ext=md"]
+      - id: pretty-format-json
+        args: ["--autofix", "--no-sort-keys"]
+      - id: check-json
+      - id: check-toml
+      - id: check-yaml
+      - id: check-xml
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-illegal-windows-names
+      - id: check-symlinks
+      - id: destroyed-symlinks
+      - id: check-vcs-permalinks
+      - id: detect-private-key
+      - id: check-merge-conflict
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
+      - id: no-commit-to-branch
+
+  # - repo: https://github.com/commitizen-tools/commitizen
+  #   rev: 953e1ba4599cc3143122ed5c3e8de3d6dfd5524d  # frozen: v4.16.2
+  #   hooks:
+  #     - id: commitizen
+  #     - id: commitizen-branch
+  #       stages:
+  #         - pre-push


### PR DESCRIPTION
pre-commit の設定 `.pre-commit-config.yaml` を導入し、#18 で追加する linter / formatter の設定を実行できるようにする。

参照する設定ファイル（markdownlint-cli2 / tombi / typos / yamllint など）は #18 で追加するため、この PR は #18 のあとに取り込む必要がある。
