### PR TITLE
ci: rename reusable-workflow callers to .yaml and set permissions

### DIFF
--- a/.github/workflows/auto-assign-pr-creator.yaml
+++ b/.github/workflows/auto-assign-pr-creator.yaml
@@ -6,4 +6,7 @@ on:
 
 jobs:
   assign:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ut-issl/se-team-hub/.github/workflows/auto-assign-pr-creator.yml@main

--- a/.github/workflows/auto-label-subsystem.yaml
+++ b/.github/workflows/auto-label-subsystem.yaml
@@ -8,4 +8,8 @@ on:
 
 jobs:
   auto-label:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     uses: ut-issl/se-team-hub/.github/workflows/auto-label-subsystem.yml@main

--- a/.github/workflows/close-set-iteration.yaml
+++ b/.github/workflows/close-set-iteration.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   set-iteration:
+    permissions: {}
     uses: ut-issl/se-team-hub/.github/workflows/set-iteration-on-close.yml@main
     secrets:
       ITERATION_AUTOMATION_APP_ID: ${{ secrets.ITERATION_AUTOMATION_APP_ID }}


### PR DESCRIPTION
既存の reusable workflow の呼び出し側ワークフローを整える。

- 拡張子を `.yml` から `.yaml` に統一（`auto-assign-pr-creator` / `auto-label-subsystem` / `close-set-iteration`）
- 各ジョブに最小権限の `permissions` を明示
