### PR TITLE
ci: add pull request auto-labeling

### DIFF
--- a/.github/labels/labeler.yaml
+++ b/.github/labels/labeler.yaml
@@ -1,0 +1,12 @@
+---
+"ci :gear:":
+  - changed-files:
+      - any-glob-to-any-file: [".github/workflows/**"]
+
+"pre-commit :hook:":
+  - changed-files:
+      - any-glob-to-any-file: [".pre-commit-config.yaml"]
+
+"documentation :notebook:":
+  - changed-files:
+      - any-glob-to-any-file: "**/*.md"

--- a/.github/workflows/manage-pull-requests.yaml
+++ b/.github/workflows/manage-pull-requests.yaml
@@ -1,0 +1,42 @@
+name: Manage Pull Requests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions: {}
+
+jobs:
+
+  label-pr:
+    name: Label PR
+    if: github.event.action != 'edited'
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labels/labeler.yaml
+          sync-labels: false
+          dot: true
+
+  # lint-pr-title:
+  #   name: Lint PR title
+  #   if: github.event.action != 'edited' || github.event.changes.title != null
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - name: Set up Commitizen
+  #       uses: commitizen-tools/setup-cz@96c75e6ae9632047f2c9b4025b9dd1624b40de8f # v0.9.1
+  #       with:
+  #         python-version: '3.x'
+  #         version: '4.16.2'
+
+  #     - name: Lint pull request title
+  #       env:
+  #         PR_TITLE: ${{ github.event.pull_request.title }}
+  #       run: cz check --message "$PR_TITLE"


### PR DESCRIPTION
変更ファイルに応じて pull request へ自動でラベルを付ける仕組みを追加する。

- `.github/labels/labeler.yaml`: 変更ファイルとラベルの対応を定義
- `manage-pull-requests.yaml`: `labeler.yaml` に基づき PR へラベルを付与するワークフロー。あわせて、Commitizen で PR タイトルを Conventional Commits に従って検証するジョブを opt-in（コメントアウト）で同梱。各リポジトリで必要に応じて有効化できる

付与対象のラベルは #23 で定義・同期するため、この PR は #23 のあとに取り込む。
