### PR TITLE
docs: add README and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 # Default owner for everything in the repository.
-# Replace @your-username with the responsible user, or with a team (e.g. @ut-issl/<team-slug>) before publishing.
-* @your-username
+# Uncomment the line below and replace @your-username with the responsible user,
+# or with a team (e.g. @ut-issl/<team-slug>) right after creating the repository.
+# * @your-username

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for everything in the repository.
+# Replace @your-username with the responsible user, or with a team (e.g. @ut-issl/<team-slug>) before publishing.
+* @your-username

--- a/README.ja.md
+++ b/README.ja.md
@@ -5,9 +5,8 @@ ISSL organization 向けの汎用リポジトリテンプレートです。
 ## 【必須】CODEOWNERS の設定
 
 このテンプレートからリポジトリを作成したら，まず [.github/CODEOWNERS](.github/CODEOWNERS) を更新してください。
-同梱されているファイルではプレースホルダーとして `@your-username` を使っていますが，このアカウントは実在しません。
 
-- 既定の `*` 行にある `@your-username` を実際のオーナー（実在するユーザー `@person` またはチーム `@ut-issl/<team-slug>`）に置き換える
+- 既定の `*` 行のコメントを外し，`@your-username` を実際のオーナー（実在するユーザー `@person` またはチーム `@ut-issl/<team-slug>`）に置き換える
 - 必要に応じて，以下の例のようにパスごとの上書きを追加する
 
   ```text

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,83 @@
+# repository-template
+
+ISSL organization 向けの汎用リポジトリテンプレートです。
+
+## 【必須】CODEOWNERS の設定
+
+このテンプレートからリポジトリを作成したら，まず [.github/CODEOWNERS](.github/CODEOWNERS) を更新してください。
+同梱されているファイルではプレースホルダーとして `@your-username` を使っていますが，このアカウントは実在しません。
+
+- 既定の `*` 行にある `@your-username` を実際のオーナー（実在するユーザー `@person` またはチーム `@ut-issl/<team-slug>`）に置き換える
+- 必要に応じて，以下の例のようにパスごとの上書きを追加する
+
+  ```text
+  .github/        @infra-manager
+  docs/           @docs-manager
+  ```
+
+詳しい構文は [GitHub ドキュメント](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
+を参照してください。
+
+## pre-commit のセットアップ
+
+このテンプレートでは，[pre-commit](https://pre-commit.com) と互換性のある [prek](https://prek.j178.dev) を推奨しています。
+
+```console
+prek install --hook-type pre-commit --hook-type pre-push
+```
+
+`pre-commit` を使う場合は，上のコマンドの `prek` を `pre-commit` に置き換えてください。
+
+## 任意で有効化できる機能
+
+デフォルトでは，PR 上で実行されるのは `lint-gh-actions`（GitHub Actions の lint）と
+`check-prek`（pre-commit フックの実行）だけです。
+その他の機能は無効化されているため，必要に応じて以下から有効化してください。
+
+### 追加の CI ジョブ
+
+以下のジョブは [ci.yaml](.github/workflows/ci.yaml) でコメントアウトされています。
+対応するブロックのコメントを外すと有効になります。
+各ジョブは関連するファイルが変更されたときにのみ実行されます。
+
+- [`validate-renovate-config`](.github/workflows/ci.yaml#L96)：Renovate 設定の検証
+- [`lint-markdown`](.github/workflows/ci.yaml#L122)：Markdown ファイルの lint
+- [`lint-json5`](.github/workflows/ci.yaml#L169)：JSON5 ファイルの lint
+- [`lint-toml`](.github/workflows/ci.yaml#L203)：TOML ファイルの lint と format
+- [`lint-yaml`](.github/workflows/ci.yaml#L230)：YAML ファイルの lint
+- [`check-typos`](.github/workflows/ci.yaml#L282)：タイポの検出
+
+### Conventional Commits の強制（Commitizen）
+
+[commitizen](https://github.com/commitizen-tools/commitizen) を使って，コミットメッセージと PR タイトルに
+[Conventional Commits](https://www.conventionalcommits.org) を適用します。
+有効化すると，すべてのコミットと PR タイトルが仕様に従っている必要があります。
+PR タイトルの lint は，squash merge を使う場合に特に有用です
+（デフォルトでは，PR タイトルが squash 後のコミットの subject になるため）。
+
+以下の 2 つのブロックのコメントを外してください。
+
+- [`lint-commit-messages`（ci.yaml 内）](.github/workflows/ci.yaml#L313)
+- [`lint-pr-title`（manage-pull-requests.yaml 内）](.github/workflows/manage-pull-requests.yaml#L27)
+
+Conventional Commits に従ったコミットメッセージを対話的に作成するには，次のコマンドを使います。
+
+```console
+uv tool install commitizen
+cz commit
+```
+
+### zizmor の advanced security アップロード
+
+`lint-gh-actions` ジョブは [zizmor](https://github.com/zizmorcore/zizmor) を `advanced-security: false` で実行しており，
+SARIF レポートの GitHub code scanning へのアップロードは行いません。
+**public** リポジトリでは，[ci.yaml#L94](.github/workflows/ci.yaml#L94) の `false` を `true` に変更すると
+検出結果を Security タブに表示できます。
+private リポジトリでアップロードを有効化するには，GitHub Advanced Security が必要です。
+
+### Renovate
+
+[Renovate](https://docs.renovatebot.com) は [.github/renovate.json5](.github/renovate.json5) で事前設定されており，
+Action の SHA，[ci.yaml](.github/workflows/ci.yaml) 内で固定しているツールバージョン，pre-commit フックを追跡するようになっています。
+有効化するには，[renovate.json5#L3](.github/renovate.json5#L3) の `enabled: false,` 行を削除する
+（または `true` に変更する）とともに，Renovate GitHub App がリポジトリにインストールされていることを確認してください。

--- a/README.md
+++ b/README.md
@@ -1,0 +1,84 @@
+# repository-template
+
+General-purpose repository template for the ISSL organization.
+
+## [Required] Configure CODEOWNERS
+
+You must update [.github/CODEOWNERS](.github/CODEOWNERS) right after creating a repository from this template.
+The shipped file uses `@your-username` as a placeholder, which does not resolve to any real account.
+
+- Replace `@your-username` on the default `*` line with the actual owner —
+  a real user (`@person`) or a team (`@ut-issl/<team-slug>`).
+- Add path-specific overrides as needed, for example:
+
+  ```text
+  .github/        @infra-manager
+  docs/           @docs-manager
+  ```
+
+See the [GitHub docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
+for the full syntax.
+
+## Pre-commit Setup
+
+This template uses [prek](https://prek.j178.dev), a faster drop-in replacement for [pre-commit](https://pre-commit.com).
+
+```console
+prek install --hook-type pre-commit --hook-type pre-push
+```
+
+If you prefer `pre-commit`, substitute `pre-commit` for `prek` in the command above.
+
+## Opt-in Features
+
+By default only `lint-gh-actions` (GitHub Actions workflow lint) and `check-prek` (runs the pre-commit hooks)
+run on PRs; everything else is disabled.
+Enable any of the below if you want them.
+
+### Additional CI Jobs
+
+The following jobs are commented out in [ci.yaml](.github/workflows/ci.yaml).
+Uncomment the corresponding block to enable each one.
+Each job runs only when the relevant files change.
+
+- [`validate-renovate-config`](.github/workflows/ci.yaml#L96) — validate the Renovate config
+- [`lint-markdown`](.github/workflows/ci.yaml#L122) — lint Markdown files
+- [`lint-json5`](.github/workflows/ci.yaml#L169) — lint JSON5 files
+- [`lint-toml`](.github/workflows/ci.yaml#L203) — lint and format TOML files
+- [`lint-yaml`](.github/workflows/ci.yaml#L230) — lint YAML files
+- [`check-typos`](.github/workflows/ci.yaml#L282) — check for typos
+
+### Conventional Commits Enforcement (Commitizen)
+
+Enforces [Conventional Commits](https://www.conventionalcommits.org) on commit messages and PR titles
+via [commitizen](https://github.com/commitizen-tools/commitizen).
+Once enabled, all commits and PR titles must follow the spec.
+Linting the PR title is especially useful with squash merging,
+since the PR title becomes the subject of the squashed commit by default.
+
+Uncomment both blocks:
+
+- [`lint-commit-messages` in ci.yaml](.github/workflows/ci.yaml#L313)
+- [`lint-pr-title` in manage-pull-requests.yaml](.github/workflows/manage-pull-requests.yaml#L27)
+
+To author Conventional Commits interactively:
+
+```console
+uv tool install commitizen
+cz commit
+```
+
+### zizmor Advanced Security Upload
+
+The `lint-gh-actions` job runs [zizmor](https://github.com/zizmorcore/zizmor) with `advanced-security: false`,
+which skips uploading the SARIF report to GitHub code scanning.
+On **public** repositories, change `false` to `true` at [ci.yaml#L94](.github/workflows/ci.yaml#L94)
+to surface findings in the Security tab.
+Private repositories require GitHub Advanced Security to enable the upload.
+
+### Renovate
+
+[Renovate](https://docs.renovatebot.com) is preconfigured in [.github/renovate.json5](.github/renovate.json5)
+to track Action SHAs, pinned tool versions inside [ci.yaml](.github/workflows/ci.yaml), and pre-commit hooks.
+To opt in, remove the `enabled: false,` line at [renovate.json5#L3](.github/renovate.json5#L3)
+(or change it to `true`) and make sure the Renovate GitHub App is installed for the repository.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@ General-purpose repository template for the ISSL organization.
 ## [Required] Configure CODEOWNERS
 
 You must update [.github/CODEOWNERS](.github/CODEOWNERS) right after creating a repository from this template.
-The shipped file uses `@your-username` as a placeholder, which does not resolve to any real account.
 
-- Replace `@your-username` on the default `*` line with the actual owner —
+- Uncomment the default `*` line and replace `@your-username` with the actual owner —
   a real user (`@person`) or a team (`@ut-issl/<team-slug>`).
 - Add path-specific overrides as needed, for example:
 


### PR DESCRIPTION
テンプレートの利用方法をまとめた `README.md` と `.github/CODEOWNERS` を追加する。

- `README.md` / `README.ja.md`: CODEOWNERS の設定、pre-commit のセットアップ、opt-in 機能（追加 CI ジョブ / Commitizen / zizmor / Renovate）の説明
- `.github/CODEOWNERS`: 既定のオーナー設定（利用時に置き換える前提のプレースホルダ）
