### PR TITLE
ci: adjust zizmor advanced security upload

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,7 +91,12 @@ jobs:
         with:
           version: 'v1.24.1'
           online-audits: false
-          advanced-security: false  # set to true on public repos to upload SARIF to GitHub code scanning
+          advanced-security: >-
+            ${{
+              github.event.repository.private == false &&
+              (github.event_name != 'pull_request' ||
+              github.event.pull_request.head.repo.full_name == github.repository)
+            }}
 
   # validate-renovate-config:
   #   name: Validate Renovate config

--- a/README.ja.md
+++ b/README.ja.md
@@ -66,14 +66,6 @@ uv tool install commitizen
 cz commit
 ```
 
-### zizmor の advanced security アップロード
-
-`lint-gh-actions` ジョブは [zizmor](https://github.com/zizmorcore/zizmor) を `advanced-security: false` で実行しており，
-SARIF レポートの GitHub code scanning へのアップロードは行いません。
-**public** リポジトリでは，[ci.yaml#L94](.github/workflows/ci.yaml#L94) の `false` を `true` に変更すると
-検出結果を Security タブに表示できます。
-private リポジトリでアップロードを有効化するには，GitHub Advanced Security が必要です。
-
 ### Renovate
 
 [Renovate](https://docs.renovatebot.com) は [.github/renovate.json5](.github/renovate.json5) で事前設定されており，

--- a/README.md
+++ b/README.md
@@ -67,14 +67,6 @@ uv tool install commitizen
 cz commit
 ```
 
-### zizmor Advanced Security Upload
-
-The `lint-gh-actions` job runs [zizmor](https://github.com/zizmorcore/zizmor) with `advanced-security: false`,
-which skips uploading the SARIF report to GitHub code scanning.
-On **public** repositories, change `false` to `true` at [ci.yaml#L94](.github/workflows/ci.yaml#L94)
-to surface findings in the Security tab.
-Private repositories require GitHub Advanced Security to enable the upload.
-
 ### Renovate
 
 [Renovate](https://docs.renovatebot.com) is preconfigured in [.github/renovate.json5](.github/renovate.json5)


### PR DESCRIPTION
- Enable zizmor SARIF upload only when the repository is public.
- Keep upload disabled for private repositories and fork pull_request runs.
- Remove the README opt-in instructions because the workflow now handles repository visibility automatically.
