### PR TITLE
ci(sync-labels): dry-run on pull requests and fix token permission

### DIFF
--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -9,7 +9,7 @@ on:
       - '.github/workflows/sync-labels.yaml'
       - '.github/labels/labels.yaml'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
     paths:
       - '.github/workflows/sync-labels.yaml'
       - '.github/labels/labels.yaml'
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
+      issues: write
 
     steps:
       - name: Checkout the main repository
@@ -35,4 +35,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           yaml-file: .github/labels/labels.yaml
           skip-delete: false
-          dry-run: false
+          dry-run: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
- PR-triggered runs previously executed the label sync for real (`dry-run: false` with `skip-delete: false`), so a same-repo PR editing the label definition mutated or deleted repository labels before review. Now PR runs are dry-run previews and only push to `main` / `workflow_dispatch` apply changes.
- Dropped the redundant `labeled` trigger type.
- Replaced `pull-requests: write` with `issues: write`: the label REST API requires issues write, and past runs only "worked" because every retained run was a no-op with all labels already in sync.
