### PR TITLE
ci: refresh the opt-in tombi TOML job and align tombi to v1.1.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -222,6 +222,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   permissions:
   #     contents: read
+  #     pull-requests: write
 
   #   steps:
   #     - name: Checkout the main repository
@@ -230,15 +231,62 @@ jobs:
   #         persist-credentials: false
 
   #     - name: Install Tombi
-  #       uses: tombi-toml/setup-tombi@9880d1d3ba5e745d410c697366c513b337704388 # v1.0.11
+  #       uses: tombi-toml/setup-tombi@df24458044353545055a12fe0d0742df9d3c5bea # v1.1.2
   #       with:
-  #         version: '0.11.6'
-
-  #     - name: Check TOML format
-  #       run: tombi format --check
+  #         version: '1.1.2'
 
   #     - name: Lint TOML
+  #       if: github.event_name != 'pull_request'
   #       run: tombi lint
+
+  #     - name: Set up reviewdog
+  #       if: github.event_name == 'pull_request'
+  #       uses: reviewdog/action-setup@d8a7baabd7f3e8544ee4dbde3ee41d0011c3a93f # v1.5.0
+  #       with:
+  #         reviewdog_version: 'v0.21.0'
+
+  #     - name: Lint TOML (reviewdog)
+  #       if: github.event_name == 'pull_request'
+  #       env:
+  #         REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         NO_COLOR: '1'
+  #       run: |
+  #         lint_rc=0
+  #         tombi lint --quiet > /tmp/tombi-lint-report.txt 2>&1 || lint_rc=$?
+  #         gawk '
+  #           match($0, /^[[:space:]]*(Warning|Error):[[:space:]]*(.*)$/, m) {
+  #             severity = m[1]; message = m[2]; next
+  #           }
+  #           match($0, /^[[:space:]]*at[[:space:]]+(.*):([0-9]+):([0-9]+)/, m) {
+  #             printf "%s:%s:%s: %s: %s\n", m[1], m[2], m[3], substr(severity, 1, 1), message
+  #           }
+  #         ' /tmp/tombi-lint-report.txt > /tmp/tombi-lint-report.efm.txt
+  #         reviewdog_rc=0
+  #         reviewdog < /tmp/tombi-lint-report.efm.txt \
+  #             -efm="%f:%l:%c: %t: %m" \
+  #             -name=tombi-lint \
+  #             -reporter=github-pr-review \
+  #             -fail-level=error || reviewdog_rc=$?
+  #         if [ $lint_rc -ne 0 ] && [ ! -s /tmp/tombi-lint-report.efm.txt ]; then
+  #           echo "::error title=tombi::tombi lint failed before producing parseable diagnostics"
+  #           cat /tmp/tombi-lint-report.txt
+  #           exit $lint_rc
+  #         fi
+  #         exit $reviewdog_rc
+
+  #     - name: Format TOML
+  #       run: tombi format
+
+  #     - name: Suggest TOML format changes (reviewdog)
+  #       if: github.event_name == 'pull_request'
+  #       uses: reviewdog/action-suggester@aa38384ceb608d00f84b4690cacc83a5aba307ff # v1.24.0
+  #       with:
+  #         github_token: ${{ secrets.GITHUB_TOKEN }}
+  #         tool_name: tombi-format
+  #         cleanup: 'false'
+
+  #     - name: Check TOML format
+  #       run: git diff --exit-code
 
   # lint-yaml:
   #   name: Lint YAML

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: markdownlint-cli2
 
   - repo: https://github.com/tombi-toml/tombi-pre-commit
-    rev: 92b75e984d8f88579b21001de632b48149d8166a  # frozen: v0.11.6
+    rev: 2d5dc3580d14ebb2abf2e2f50380e573418b68d8  # frozen: v1.1.2
     hooks:
       - id: tombi-format
       - id: tombi-lint


### PR DESCRIPTION
Refresh the opt-in (commented-out) `lint-toml` job: lint diagnostics and format changes are reported through reviewdog on pull requests (graded severity, `tombi-lint` / `tombi-format`), with `git diff --exit-code` enforcing formatting. The job stays commented out to preserve opt-in.

Also align the tombi version to v1.1.2 across the pre-commit hook, the setup-tombi action, and the installed CLI.
