### PR TITLE
docs(readme): fix and widen ci.yaml line references to job block ranges

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -39,12 +39,12 @@ prek install --hook-type pre-commit --hook-type pre-push
 対応するブロックのコメントを外すと有効になります。
 各ジョブは関連するファイルが変更されたときにのみ実行されます。
 
-- [`validate-renovate-config`](.github/workflows/ci.yaml#L96)：Renovate 設定の検証
-- [`lint-markdown`](.github/workflows/ci.yaml#L122)：Markdown ファイルの lint
-- [`lint-json5`](.github/workflows/ci.yaml#L169)：JSON5 ファイルの lint
-- [`lint-toml`](.github/workflows/ci.yaml#L203)：TOML ファイルの lint と format
-- [`lint-yaml`](.github/workflows/ci.yaml#L230)：YAML ファイルの lint
-- [`check-typos`](.github/workflows/ci.yaml#L282)：タイポの検出
+- [`validate-renovate-config`](.github/workflows/ci.yaml#L105)：Renovate 設定の検証
+- [`lint-markdown`](.github/workflows/ci.yaml#L131)：Markdown ファイルの lint
+- [`lint-json5`](.github/workflows/ci.yaml#L178)：JSON5 ファイルの lint
+- [`lint-toml`](.github/workflows/ci.yaml#L216)：TOML ファイルの lint と format
+- [`lint-yaml`](.github/workflows/ci.yaml#L291)：YAML ファイルの lint
+- [`check-typos`](.github/workflows/ci.yaml#L343)：タイポの検出
 
 ### Conventional Commits の強制（Commitizen）
 
@@ -56,7 +56,7 @@ PR タイトルの lint は，squash merge を使う場合に特に有用です
 
 以下の 2 つのブロックのコメントを外してください。
 
-- [`lint-commit-messages`（ci.yaml 内）](.github/workflows/ci.yaml#L313)
+- [`lint-commit-messages`（ci.yaml 内）](.github/workflows/ci.yaml#L374)
 - [`lint-pr-title`（manage-pull-requests.yaml 内）](.github/workflows/manage-pull-requests.yaml#L27)
 
 Conventional Commits に従ったコミットメッセージを対話的に作成するには，次のコマンドを使います。

--- a/README.ja.md
+++ b/README.ja.md
@@ -39,12 +39,12 @@ prek install --hook-type pre-commit --hook-type pre-push
 対応するブロックのコメントを外すと有効になります。
 各ジョブは関連するファイルが変更されたときにのみ実行されます。
 
-- [`validate-renovate-config`](.github/workflows/ci.yaml#L105)：Renovate 設定の検証
-- [`lint-markdown`](.github/workflows/ci.yaml#L131)：Markdown ファイルの lint
-- [`lint-json5`](.github/workflows/ci.yaml#L178)：JSON5 ファイルの lint
-- [`lint-toml`](.github/workflows/ci.yaml#L216)：TOML ファイルの lint と format
-- [`lint-yaml`](.github/workflows/ci.yaml#L291)：YAML ファイルの lint
-- [`check-typos`](.github/workflows/ci.yaml#L343)：タイポの検出
+- [`validate-renovate-config`](.github/workflows/ci.yaml#L105-L129)：Renovate 設定の検証
+- [`lint-markdown`](.github/workflows/ci.yaml#L131-L176)：Markdown ファイルの lint
+- [`lint-json5`](.github/workflows/ci.yaml#L178-L214)：JSON5 ファイルの lint
+- [`lint-toml`](.github/workflows/ci.yaml#L216-L289)：TOML ファイルの lint と format
+- [`lint-yaml`](.github/workflows/ci.yaml#L291-L325)：YAML ファイルの lint
+- [`check-typos`](.github/workflows/ci.yaml#L343-L372)：タイポの検出
 
 ### Conventional Commits の強制（Commitizen）
 
@@ -56,8 +56,8 @@ PR タイトルの lint は，squash merge を使う場合に特に有用です
 
 以下の 2 つのブロックのコメントを外してください。
 
-- [`lint-commit-messages`（ci.yaml 内）](.github/workflows/ci.yaml#L374)
-- [`lint-pr-title`（manage-pull-requests.yaml 内）](.github/workflows/manage-pull-requests.yaml#L27)
+- [`lint-commit-messages`（ci.yaml 内）](.github/workflows/ci.yaml#L374-L397)
+- [`lint-pr-title`（manage-pull-requests.yaml 内）](.github/workflows/manage-pull-requests.yaml#L27-L42)
 
 Conventional Commits に従ったコミットメッセージを対話的に作成するには，次のコマンドを使います。
 

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ The following jobs are commented out in [ci.yaml](.github/workflows/ci.yaml).
 Uncomment the corresponding block to enable each one.
 Each job runs only when the relevant files change.
 
-- [`validate-renovate-config`](.github/workflows/ci.yaml#L105) — validate the Renovate config
-- [`lint-markdown`](.github/workflows/ci.yaml#L131) — lint Markdown files
-- [`lint-json5`](.github/workflows/ci.yaml#L178) — lint JSON5 files
-- [`lint-toml`](.github/workflows/ci.yaml#L216) — lint and format TOML files
-- [`lint-yaml`](.github/workflows/ci.yaml#L291) — lint YAML files
-- [`check-typos`](.github/workflows/ci.yaml#L343) — check for typos
+- [`validate-renovate-config`](.github/workflows/ci.yaml#L105-L129) — validate the Renovate config
+- [`lint-markdown`](.github/workflows/ci.yaml#L131-L176) — lint Markdown files
+- [`lint-json5`](.github/workflows/ci.yaml#L178-L214) — lint JSON5 files
+- [`lint-toml`](.github/workflows/ci.yaml#L216-L289) — lint and format TOML files
+- [`lint-yaml`](.github/workflows/ci.yaml#L291-L325) — lint YAML files
+- [`check-typos`](.github/workflows/ci.yaml#L343-L372) — check for typos
 
 ### Conventional Commits Enforcement (Commitizen)
 
@@ -57,8 +57,8 @@ since the PR title becomes the subject of the squashed commit by default.
 
 Uncomment both blocks:
 
-- [`lint-commit-messages` in ci.yaml](.github/workflows/ci.yaml#L374)
-- [`lint-pr-title` in manage-pull-requests.yaml](.github/workflows/manage-pull-requests.yaml#L27)
+- [`lint-commit-messages` in ci.yaml](.github/workflows/ci.yaml#L374-L397)
+- [`lint-pr-title` in manage-pull-requests.yaml](.github/workflows/manage-pull-requests.yaml#L27-L42)
 
 To author Conventional Commits interactively:
 

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ The following jobs are commented out in [ci.yaml](.github/workflows/ci.yaml).
 Uncomment the corresponding block to enable each one.
 Each job runs only when the relevant files change.
 
-- [`validate-renovate-config`](.github/workflows/ci.yaml#L96) — validate the Renovate config
-- [`lint-markdown`](.github/workflows/ci.yaml#L122) — lint Markdown files
-- [`lint-json5`](.github/workflows/ci.yaml#L169) — lint JSON5 files
-- [`lint-toml`](.github/workflows/ci.yaml#L203) — lint and format TOML files
-- [`lint-yaml`](.github/workflows/ci.yaml#L230) — lint YAML files
-- [`check-typos`](.github/workflows/ci.yaml#L282) — check for typos
+- [`validate-renovate-config`](.github/workflows/ci.yaml#L105) — validate the Renovate config
+- [`lint-markdown`](.github/workflows/ci.yaml#L131) — lint Markdown files
+- [`lint-json5`](.github/workflows/ci.yaml#L178) — lint JSON5 files
+- [`lint-toml`](.github/workflows/ci.yaml#L216) — lint and format TOML files
+- [`lint-yaml`](.github/workflows/ci.yaml#L291) — lint YAML files
+- [`check-typos`](.github/workflows/ci.yaml#L343) — check for typos
 
 ### Conventional Commits Enforcement (Commitizen)
 
@@ -57,7 +57,7 @@ since the PR title becomes the subject of the squashed commit by default.
 
 Uncomment both blocks:
 
-- [`lint-commit-messages` in ci.yaml](.github/workflows/ci.yaml#L313)
+- [`lint-commit-messages` in ci.yaml](.github/workflows/ci.yaml#L374)
 - [`lint-pr-title` in manage-pull-requests.yaml](.github/workflows/manage-pull-requests.yaml#L27)
 
 To author Conventional Commits interactively:


### PR DESCRIPTION
The "Opt-in Features" links in both READMEs pointed to stale line numbers in `ci.yaml`. Updated the anchors so each one points to the full commented-out job block as a line range, matching the "uncomment the corresponding block" instruction. `README.md` and `README.ja.md` shared the same outdated references.

- `validate-renovate-config`: #L96 → #L105-L129
- `lint-markdown`: #L122 → #L131-L176
- `lint-json5`: #L169 → #L178-L214
- `lint-toml`: #L203 → #L216-L289
- `lint-yaml`: #L230 → #L291-L325
- `check-typos`: #L282 → #L343-L372
- `lint-commit-messages`: #L313 → #L374-L397
- `lint-pr-title` (manage-pull-requests.yaml): #L27 → #L27-L42
